### PR TITLE
Fix incorrect plugin references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `eslint-plugin-freeze-global` to the plugins section of your `.eslintrc` con
 ```json
 {
     "plugins": [
-        "eslint-plugin-freeze-global"
+        "freeze-global"
     ]
 }
 ```
@@ -36,7 +36,7 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "eslint-plugin-freeze-global/no-mutable-global": 2
+        "freeze-global/no-mutable-global": 2
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const GLOBAL = Object.freeze({
 ```json
 {
     "rules": {
-        "eslint-plugin-freeze-global/no-naked-global": 2
+        "freeze-global/no-naked-global": 2
     }
 }
 ```


### PR DESCRIPTION
I tried your instructions for adding the rule, but it didn't work at first; I then realized that it's because the references you suggested for the rule are prefixed with "eslint-plugin-".  Not sure if this was supported by ESLint in the past.  Just thought I'd submit this change so that others don't get tripped up at first.

Also, great plugin!  I'm impressed it even works correctly with a custom-written deepFreeze function.